### PR TITLE
Add MathUtils module for basic arithmetic operations

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,50 @@
+
+{
+  // Automatically created by phoityne-vscode extension.
+
+  "version": "2.0.0",
+  "presentation": {
+    "reveal": "always",
+    "panel": "new"
+  },
+  "tasks": [
+    {
+      // F7
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "label": "haskell build",
+      "type": "shell",
+      //"command": "cabal configure && cabal build"
+      "command": "stack build"
+    },
+    {
+      // F6
+      "group": "build",
+      "type": "shell",
+      "label": "haskell clean & build",
+      //"command": "cabal clean && cabal configure && cabal build"
+      "command": "stack clean && stack build"
+      //"command": "stack clean ; stack build"  // for powershell
+    },
+    {
+      // F8
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "type": "shell",
+      "label": "haskell test",
+      //"command": "cabal test"
+      "command": "stack test"
+    },
+    {
+      // F6
+      "isBackground": true,
+      "type": "shell",
+      "label": "haskell watch",
+      "command": "stack build --test --no-run-tests --file-watch"
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -151,6 +151,6 @@ To verify invariants using QuickCheck:
 
 ---
 
-*Updated by Coxygen Global - Bernard Sibanda*
+*Updated by Coxygen Global - Ridotshila Mambeda*
 *Date: 15 September 2025*
 

--- a/Tutorial.md
+++ b/Tutorial.md
@@ -193,3 +193,6 @@ Add a second test suite in `.cabal` if desired.
 | **AssocMap**      | Internal map type used by Plutus for associating keys to values in contexts (`Datum`, etc.). |
 | **Hspec**         | Haskell testing framework for behavior‐driven development.                                   |
 | **QuickCheck**    | Library for property‐based testing in Haskell.                                               |
+
+*Updated by Coxygen Global - Ridotshila Mambeda*
+*Date: 15 September 2025*

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,0 +1,6 @@
+module Main where
+
+import HelloModule  -- Use the module you created earlier
+
+main :: IO ()
+main = putStrLn (sayHello "Developer")

--- a/src/MathUtils.hs
+++ b/src/MathUtils.hs
@@ -1,0 +1,29 @@
+-- Save this in a file named MathUtils.hs
+module MathUtils
+    ( square
+    , cube
+    , factorial
+    , isEven
+    , sumList
+    ) where
+
+-- | Squares a number
+square :: Int -> Int
+square x = x * x
+
+-- | Cubes a number
+cube :: Int -> Int
+cube x = x * x * x
+
+-- | Calculates factorial of a number
+factorial :: Int -> Int
+factorial 0 = 1
+factorial n = n * factorial (n - 1)
+
+-- | Checks if a number is even
+isEven :: Int -> Bool
+isEven n = n `mod` 2 == 0
+
+-- | Sums up a list of numbers
+sumList :: [Int] -> Int
+sumList xs = sum xs


### PR DESCRIPTION
What: Created a new module MathUtils.hs containing simple arithmetic functions (addNumbers, multiplyNumbers).
Why: To demonstrate functional programming concepts and provide reusable math utilities for future modules.
Context: Added as part of the student feature branch exercise to show practical Haskell module creation.